### PR TITLE
Fix potential text template variable shadowing

### DIFF
--- a/cmd/bounce/handlers.go
+++ b/cmd/bounce/handlers.go
@@ -117,10 +117,10 @@ func echoHandler(templateText string, coloredJSON bool, coloredJSONIndent int) h
 
 		mw := io.MultiWriter(w, os.Stdout)
 
-		textTemplate := textTemplate.Must(textTemplate.New("echoHandler").Parse(templateText))
+		tmpl := textTemplate.Must(textTemplate.New("echoHandler").Parse(templateText))
 
 		writeTemplate := func() {
-			err := textTemplate.Execute(mw, ourResponse)
+			err := tmpl.Execute(mw, ourResponse)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 


### PR DESCRIPTION
We shadowed the textTemplate import name (for text/template) within the echoHandler function when setting up our template with the Must() method. While Go was still able to sort everything out, it was confusing to look at (for me if nobody else).