### PR TITLE
Extend / Enhance JSON decoding error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,9 +410,13 @@ and with colorized JSON output enabled:
   - <https://stackoverflow.com/questions/24556001/how-to-range-over-slice-of-structs-instead-of-struct-of-slices>
   - <https://golangcode.com/get-the-request-ip-addr/>
   - <https://github.com/eddturtle/golangcode-site>
-  - <https://stackoverflow.com/questions/19038598/how-can-i-pretty-print-json-using-go/42426889>
+
+- Request body
   - <https://stackoverflow.com/questions/43021058/golang-read-request-body/43021236#43021236>
   - <https://www.alexedwards.net/blog/how-to-properly-parse-a-json-request-body>
+  - <https://stackoverflow.com/questions/33532374/in-go-how-can-i-reuse-a-readcloser>
+
+- HTTP Server
   - <https://blog.simon-frey.eu/go-as-in-golang-standard-net-http-config-will-break-your-production/>
   - <https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779>
 
@@ -420,7 +424,8 @@ and with colorized JSON output enabled:
   - <https://github.com/apex/log>
   - <https://brandur.org/logfmt>
 
-- Colored JSON
+- Formatted / Colored JSON
+  - <https://stackoverflow.com/questions/19038598/how-can-i-pretty-print-json-using-go/42426889>
   - <https://stackoverflow.com/a/50549770/903870>
   - <https://github.com/TylerBrock/colorjson>
 

--- a/cmd/bounce/decode-json-body.go
+++ b/cmd/bounce/decode-json-body.go
@@ -1,0 +1,92 @@
+// https://www.alexedwards.net/blog/how-to-properly-parse-a-json-request-body
+//
+// If you enjoyed this blog post, don't forget to check out my new book
+// (https://lets-go.alexedwards.net/) about how to build professional web
+// applications with Go!
+//
+// Follow me on Twitter @ajmedwards.
+//
+// All code snippets in this post are free to use under the MIT Licence.
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/golang/gddo/httputil/header"
+)
+
+type malformedRequest struct {
+	status int
+	msg    string
+}
+
+// malformedRequest wraps errors from decoding JSON request bodies
+func (mr *malformedRequest) Error() string {
+	return mr.msg
+}
+
+// decodeJSONBody is a helper function which wraps common JSON request body
+// decoding logic. This allows for code re-use between multiple endpoints.
+func decodeJSONBody(w http.ResponseWriter, r *http.Request, dst interface{}) error {
+	if r.Header.Get("Content-Type") != "" {
+		value, _ := header.ParseValueAndParams(r.Header, "Content-Type")
+		if value != "application/json" {
+			msg := "Content-Type header is not application/json"
+			return &malformedRequest{status: http.StatusUnsupportedMediaType, msg: msg}
+		}
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1048576)
+
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+
+	err := dec.Decode(&dst)
+	if err != nil {
+		var syntaxError *json.SyntaxError
+		var unmarshalTypeError *json.UnmarshalTypeError
+
+		switch {
+		case errors.As(err, &syntaxError):
+			msg := fmt.Sprintf("Request body contains badly-formed JSON (at position %d)", syntaxError.Offset)
+			return &malformedRequest{status: http.StatusBadRequest, msg: msg}
+
+		case errors.Is(err, io.ErrUnexpectedEOF):
+			msg := "Request body contains badly-formed JSON"
+			return &malformedRequest{status: http.StatusBadRequest, msg: msg}
+
+		case errors.As(err, &unmarshalTypeError):
+			msg := fmt.Sprintf("Request body contains an invalid value for the %q field (at position %d)", unmarshalTypeError.Field, unmarshalTypeError.Offset)
+			return &malformedRequest{status: http.StatusBadRequest, msg: msg}
+
+		case strings.HasPrefix(err.Error(), "json: unknown field "):
+			fieldName := strings.TrimPrefix(err.Error(), "json: unknown field ")
+			msg := fmt.Sprintf("Request body contains unknown field %s", fieldName)
+			return &malformedRequest{status: http.StatusBadRequest, msg: msg}
+
+		case errors.Is(err, io.EOF):
+			msg := "Request body must not be empty"
+			return &malformedRequest{status: http.StatusBadRequest, msg: msg}
+
+		case err.Error() == "http: request body too large":
+			msg := "Request body must not be larger than 1MB"
+			return &malformedRequest{status: http.StatusRequestEntityTooLarge, msg: msg}
+
+		default:
+			return err
+		}
+	}
+
+	if dec.More() {
+		msg := "Request body must only contain a single JSON object"
+		return &malformedRequest{status: http.StatusBadRequest, msg: msg}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Goals

- Improve JSON decoding/parsing to handle common errors that we are not currently handling
- Re-use existing code from a professional developer that has already tread this path *and* whose code I can both understand now (surface level) and glean further ideas from (deeper level) as my skills progress

## Changes

- Add `decodeJSONBody()` method and associated `malformedRequest` type provided by Alex Edwards (many thanks for sharing!)
  - Article: https://www.alexedwards.net/blog/how-to-properly-parse-a-json-request-body
  - License: MIT (same as this codebase)
  - Book: https://lets-go.alexedwards.net/
  - Twitter: https://twitter.com/ajmedwards

- Update JSON-specific endpoint to use `decodeJSONBody()`

- Update `handleJSONParseError` helper function to specifically
  work with a `malformedRequest` error type if provided

- Explicitly restore request body 'stream' after reading it so
  that the `decodeJSONBody()` function will have access to the
  request body as it was first read.

  As I am continually reminded, reading from a "stream" (such as
  the request body) results in the data within being cleared.

  "You can only read from a stream once".

## References

- fixes #15 

- https://www.alexedwards.net/blog/how-to-properly-parse-a-json-request-body