### PR TITLE
Move golangci-lint settings to external file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/bounce
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+linters:
+  enable:
+    - dogsled
+    - goimports
+    - gosec
+    - stylecheck
+    - goconst
+    - depguard
+    - prealloc
+    - misspell
+    - maligned
+    - dupl
+    - unconvert
+    - golint
+    - gocritic
+    - scopelint

--- a/Makefile
+++ b/Makefile
@@ -86,19 +86,7 @@ linting:
 	@golint -set_exit_status ./...
 
 	@echo "Running golangci-lint ..."
-	@golangci-lint run \
-		-E goimports \
-		-E gosec \
-		-E stylecheck \
-		-E goconst \
-		-E depguard \
-		-E prealloc \
-		-E misspell \
-		-E maligned \
-		-E dupl \
-		-E unconvert \
-		-E golint \
-		-E gocritic
+	@golangci-lint run
 
 	@echo "Running staticcheck ..."
 	@staticcheck ./...


### PR DESCRIPTION
Instead of specifying the options within just the Makefile,
specify them in an external config file that golangci-lint
will look for/use automatically.

fixes #34