### PR TITLE
Fix URL syntax in project repo link

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,6 +1,6 @@
 # Copyright 2020 Adam Chalkley
 #
-# https:#github.com/atc0005/bounce
+# https://github.com/atc0005/bounce
 #
 # Licensed under the MIT License. See LICENSE file in the project root for
 # full license information.


### PR DESCRIPTION
Some paste search/replace operation matched more than was intended.