### PR TITLE
Update unmonitored dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ go 1.13
 //)
 
 require (
-	github.com/TylerBrock/colorjson v0.0.0-20180527164720-95ec53f28296
+	github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2
 	github.com/apex/log v1.6.0
 
 	//gopkg.in/dasrick/go-teams-notify.v1 v1.2.0
@@ -39,6 +39,6 @@ require (
 	github.com/atc0005/go-teams-notify v1.3.1-0.20200419155834-55cca556e726
 	github.com/atc0005/send2teams v0.4.5
 	github.com/fatih/color v1.9.0 // indirect
-	github.com/golang/gddo v0.0.0-20200324184333-3c2cc9a6329d
+	github.com/golang/gddo v0.0.0-20200715224205-051695c33a3f
 	github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.16.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/TylerBrock/colorjson v0.0.0-20180527164720-95ec53f28296 h1:JYWTroLXcNzSCgu66NMgdjwoMHQRbv2SoOVNFb4kRkE=
-github.com/TylerBrock/colorjson v0.0.0-20180527164720-95ec53f28296/go.mod h1:VSw57q4QFiWDbRnjdX8Cb3Ow0SFncRw+bA/ofY6Q83w=
+github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2 h1:ZBbLwSJqkHBuFDA6DUhhse0IGJ7T5bemHyNILUjvOq4=
+github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2/go.mod h1:VSw57q4QFiWDbRnjdX8Cb3Ow0SFncRw+bA/ofY6Q83w=
 github.com/apex/log v1.6.0 h1:Y50wF1PBIIexIgTm0/7G6gcLitkO5jHK5Mb6wcMY0UI=
 github.com/apex/log v1.6.0/go.mod h1:x7s+P9VtvFBXge9Vbn+8TrqKmuzmD35TTkeBHul8UtY=
 github.com/apex/logs v1.0.0/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
@@ -10,8 +10,6 @@ github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
 github.com/atc0005/go-teams-notify v1.3.1-0.20200419155834-55cca556e726 h1:pUJFxj7XRR6UxgWTvG4BCf1cVsn7nNqxdigBhMd1r/c=
 github.com/atc0005/go-teams-notify v1.3.1-0.20200419155834-55cca556e726/go.mod h1:zUADEXrhalWyaQvxzYgHswljBWycIpX1UAFrggjcdi4=
-github.com/atc0005/send2teams v0.4.4 h1:d7OfycX7MEcF088Ohy/QdgUT0dkYdw9xPr/E7EMDwXQ=
-github.com/atc0005/send2teams v0.4.4/go.mod h1:uS4e7eZnRBhY/ia8crocFu3PM2Rl0VxHGA+r3Rb8eXo=
 github.com/atc0005/send2teams v0.4.5 h1:VJ6hbMJ/oAJcmb1BxbjZOVOLwrQD+DT6IKbrFhI8iEI=
 github.com/atc0005/send2teams v0.4.5/go.mod h1:86mW/aTXHOItQ/kHnfIx/5QDzLjZK09/baa+XxBYisE=
 github.com/aws/aws-sdk-go v1.20.6 h1:kmy4Gvdlyez1fV4kw5RYxZzWKVyuHZHgPWeU/YvRsV4=
@@ -31,8 +29,8 @@ github.com/garyburd/redigo v1.1.1-0.20170914051019-70e1b1943d4f/go.mod h1:NR3MbY
 github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80nA=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.6.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/golang/gddo v0.0.0-20200324184333-3c2cc9a6329d h1:ZJhGJay808i+klrJbox3i5NMVerJ3/tEhtOTeQpPwJQ=
-github.com/golang/gddo v0.0.0-20200324184333-3c2cc9a6329d/go.mod h1:sam69Hju0uq+5uvLJUMDlsKlQ21Vrs1Kd/1YFPNYdOU=
+github.com/golang/gddo v0.0.0-20200715224205-051695c33a3f h1:pJ14NLr9vXdAMKYLtypCmM7spi+S2A0iTkwMYNcVBZs=
+github.com/golang/gddo v0.0.0-20200715224205-051695c33a3f/go.mod h1:sam69Hju0uq+5uvLJUMDlsKlQ21Vrs1Kd/1YFPNYdOU=
 github.com/golang/lint v0.0.0-20170918230701-e5d664eb928e/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -141,8 +139,6 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c h1:grhR+C34yXImVGp7EzNk+DTIk+323eIUWOmEevy6bDo=

--- a/vendor/github.com/TylerBrock/colorjson/colorjson.go
+++ b/vendor/github.com/TylerBrock/colorjson/colorjson.go
@@ -147,6 +147,8 @@ func (f *Formatter) marshalValue(val interface{}, buf *bytes.Buffer, depth int) 
 		buf.WriteString(f.sprintColor(f.BoolColor, (strconv.FormatBool(v))))
 	case nil:
 		buf.WriteString(f.sprintColor(f.NullColor, null))
+	case json.Number:
+		buf.WriteString(f.sprintColor(f.NumberColor, v.String()))
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/TylerBrock/colorjson v0.0.0-20180527164720-95ec53f28296
+# github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2
 github.com/TylerBrock/colorjson
 # github.com/apex/log v1.6.0
 github.com/apex/log
@@ -9,13 +9,13 @@ github.com/apex/log/handlers/logfmt
 github.com/apex/log/handlers/text
 # github.com/atc0005/go-teams-notify v1.3.1-0.20200419155834-55cca556e726
 github.com/atc0005/go-teams-notify
-# github.com/atc0005/send2teams v0.4.4
+# github.com/atc0005/send2teams v0.4.5
 github.com/atc0005/send2teams/teams
 # github.com/fatih/color v1.9.0
 github.com/fatih/color
 # github.com/go-logfmt/logfmt v0.4.0
 github.com/go-logfmt/logfmt
-# github.com/golang/gddo v0.0.0-20200324184333-3c2cc9a6329d
+# github.com/golang/gddo v0.0.0-20200715224205-051695c33a3f
 github.com/golang/gddo/httputil/header
 # github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
 github.com/kr/logfmt


### PR DESCRIPTION
Dependabot is still having issues monitoring this repo,
but thanks to VSCode, the following dependencies were
flagged for updates:

- atc0005/send2teams
  - upgraded from `v0.4.4` to `v0.4.5`
  - note: GH-79 was created not long after I initially
    created this branch (result of a forced check)

- TylerBrock/colorjson
  - upgraded from `v0.0.0-20180527164720-95ec53f28296`
    to `v0.0.0-20200706003622-8a50f05110d2`

- golang/gddo
  - upgraded from `v0.0.0-20200324184333-3c2cc9a6329d`
    to `v0.0.0-20200715224205-051695c33a3f`