### PR TITLE
Add missing Makefile changes from PR 88

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@
 # https://gist.github.com/subfuzion/0bd969d08fe0d8b5cc4b23c795854a13
 # https://stackoverflow.com/questions/10858261/abort-makefile-if-variable-not-set
 # https://stackoverflow.com/questions/38801796/makefile-set-if-variable-is-empty
+# https://github.com/golangci/golangci-lint#install
+# https://github.com/golangci/golangci-lint/releases/latest
 
 SHELL = /bin/bash
 
@@ -31,10 +33,6 @@ OUTPUTDIR 				= release_assets
 
 # https://gist.github.com/TheHippo/7e4d9ec4b7ed4c0d7a39839e6800cc16
 VERSION 				= $(shell git describe --always --long --dirty)
-
-# https://github.com/golangci/golangci-lint#install
-# https://github.com/golangci/golangci-lint/releases/latest
-GOLANGCI_LINT_VERSION		= v1.25.1
 
 # The default `go build` process embeds debugging information. Building
 # without that debugging information reduces the binary size by around 28%.
@@ -67,8 +65,8 @@ lintinstall:
 	@echo "Explicitly enabling Go modules mode per command"
 	(cd; GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck)
 
-	@echo Installing golangci-lint ${GOLANGCI_LINT_VERSION} per official binary installation docs ...
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
+	@echo Installing latest stable golangci-lint version per official installation script ...
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin
 	golangci-lint --version
 
 	@echo "Finished updating linting tools"


### PR DESCRIPTION
Makefile `lintinstall` recipe installs the very latest
stable version of the `golangci-lint` binary instead
of locking a specific version.

The intent is to help reduce dependency "gardening".

refs GH-88