### PR TITLE
Fix various gocritic linting errors

### DIFF
--- a/cmd/bounce/handlers.go
+++ b/cmd/bounce/handlers.go
@@ -119,7 +119,7 @@ func echoHandler(ctx context.Context, tmpl *textTemplate.Template, coloredJSON b
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		// For now, we generate plain text responses
-		//w.Header().Set("Content-Type", "text/plain")
+		// w.Header().Set("Content-Type", "text/plain")
 
 		ourResponse := clientRequestDetails{}
 

--- a/cmd/bounce/notify.go
+++ b/cmd/bounce/notify.go
@@ -280,7 +280,7 @@ func notifyQueueMonitor(ctx context.Context, delay time.Duration, notifyQueues .
 			// if they're not available
 
 			var itemsFound bool
-			//log.Debugf("Length of queues: %d", len(queues))
+			// log.Debugf("Length of queues: %d", len(queues))
 			for _, notifyQueue := range notifyQueues {
 
 				switch queue := notifyQueue.Channel.(type) {
@@ -847,7 +847,7 @@ func StartNotifyMgr(ctx context.Context, cfg *config.Config, notifyWorkQueue <-c
 				statsUpdate.TeamsMsgSuccess = 1
 			}
 
-			//log.Debugf("statsUpdate: %#v", statsUpdate)
+			// log.Debugf("statsUpdate: %#v", statsUpdate)
 
 			go func() {
 				notifyStatsQueue <- statsUpdate

--- a/config/flags.go
+++ b/config/flags.go
@@ -36,8 +36,8 @@ func (c *Config) handleFlagsConfig() error {
 
 	// FIXME: Is this needed for any reason since our mainFlagSet has already
 	// been parsed?
-	//flag.CommandLine = mainFlagSet
-	//flag.Parse()
+	// flag.CommandLine = mainFlagSet
+	// flag.Parse()
 	if err := mainFlagSet.Parse(os.Args[1:]); err != nil {
 		return err
 	}


### PR DESCRIPTION
- commentFormatting
  - minor whitespace tweaks

- exitAfterDefer
  - legitimate complaint
  - fixed by using an initial defer of a pointer to int with
    a default value that indicates success. This can be
    overridden as needed to indicate application failure
    without blocking other deferred functions from running.