### PR TITLE
Fix Makefile build cmd to create static binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ SHELL = /bin/bash
 WHAT					= bounce
 
 # What package holds the "version" variable used in branding/version output?
-VERSION_VAR_PKG			= github.com/atc0005/$(APPNAME)/config
+VERSION_VAR_PKG			= $(shell go list .)/config
 
 OUTPUTDIR 				= release_assets
 
@@ -38,11 +38,31 @@ VERSION 				= $(shell git describe --always --long --dirty)
 # The default `go build` process embeds debugging information. Building
 # without that debugging information reduces the binary size by around 28%.
 #
+# We also include additional flags in an effort to generate static binaries
+# that do not have external dependencies. As of Go 1.15 this still appears to
+# be a mixed bag, so YMMV.
+#
+# See https://github.com/golang/go/issues/26492 for more information.
+#
+# -s
+#	Omit the symbol table and debug information.
+#
+# -w
+#	Omit the DWARF symbol table.
+#
+# -tags 'osusergo,netgo'
+#	Use pure Go implementation of user and group id/name resolution.
+#	Use pure Go implementation of DNS resolver.
+#
 # -trimpath
 #	https://golang.org/cmd/go/
 #   removes all file system paths from the compiled executable, to improve
 #   build reproducibility.
-BUILDCMD				=	go build -mod=vendor -a -trimpath -ldflags="-s -w -X $(VERSION_VAR_PKG).version=$(VERSION)"
+#
+# CGO_ENABLED=0
+#	https://golang.org/cmd/cgo/
+#	explicitly disable use of cgo
+BUILDCMD				=	CGO_ENABLED=0 go build -mod=vendor -a -trimpath -tags 'osusergo,netgo' -ldflags="-s -w -X $(VERSION_VAR_PKG).version=$(VERSION)"
 GOCLEANCMD				=	go clean -mod=vendor ./...
 GITCLEANCMD				= 	git clean -xfd
 CHECKSUMCMD				=	sha256sum -b


### PR DESCRIPTION
The previous build command produces dynamic executables
instead of the intended (but not well noted in the Makefile)
static executables. This commit includes changes noted in
upstream `golang/go` issues which appear to work as intended
for others.

I also include doc comments and reference links describing
the use of the updated build options list and some problems
that I encountered during testing of `linkmode=external`.

- fixes GH-108
- refs golang/go 38789
- refs golang/go 26492