### PR TITLE
Fix explicit exit code handling

### DIFF
--- a/cmd/bounce/main.go
+++ b/cmd/bounce/main.go
@@ -42,14 +42,14 @@ func main() {
 	// default exit code that matches expectations, but allow explicitly
 	// setting the exit code in such a way that is compatible with using
 	// deferred function calls throughout the application.
-	var appExitCode *int
+	var appExitCode int
 	defer func(code *int) {
 		var exitCode int
 		if code != nil {
 			exitCode = *code
 		}
 		os.Exit(exitCode)
-	}(appExitCode)
+	}(&appExitCode)
 
 	// This will use default logging settings (level filter, destination)
 	// as the application hasn't "booted up" far enough to apply custom
@@ -59,11 +59,11 @@ func main() {
 	appConfig, err := config.NewConfig()
 	if err != nil {
 		if errors.Is(err, flag.ErrHelp) {
-			*appExitCode = 0
+			appExitCode = 0
 			return
 		}
 		log.Errorf("Failed to initialize application: %s", err)
-		*appExitCode = 1
+		appExitCode = 1
 		return
 	}
 
@@ -201,7 +201,7 @@ func main() {
 		// any other error message.
 		if !errors.Is(err, http.ErrServerClosed) {
 			log.Errorf("error occurred while running httpServer: %v", err)
-			*appExitCode = 1
+			appExitCode = 1
 			return
 		}
 	}


### PR DESCRIPTION
Avoid assignment to uninitialized pointer by using a value
type and explicitly passing a reference to the value type
into the deferred anonymous function. This allows the
intended behavior to work as expected.

refs GH-110