### PR TITLE
Fix govet:fieldalignment linting errors

### DIFF
--- a/cmd/bounce/decode-json-body.go
+++ b/cmd/bounce/decode-json-body.go
@@ -22,8 +22,8 @@ import (
 )
 
 type malformedRequest struct {
-	status int
 	msg    string
+	status int
 }
 
 // malformedRequest wraps errors from decoding JSON request bodies

--- a/cmd/bounce/notify.go
+++ b/cmd/bounce/notify.go
@@ -15,13 +15,13 @@ import (
 // error or success conditions
 type NotifyResult struct {
 
-	// Val is the non-error condition message to return from a notification
-	// operation
-	Val string
-
 	// Err is the error condition message to return from a notification
 	// operation
 	Err error
+
+	// Val is the non-error condition message to return from a notification
+	// operation
+	Val string
 
 	// Success indicates whether the notification attempt succeeded or if it
 	// failed for one reason or another (remote API, timeout, cancellation,
@@ -32,12 +32,13 @@ type NotifyResult struct {
 // NotifyQueue represents a channel used to queue input data and responses
 // between the main application, the notifications manager and "notifiers".
 type NotifyQueue struct {
-	// The name of a queue. This is intended for display in log messages or
-	// other output to identify queues with pending items.
-	Name string
 
 	// Channel is a channel used to transport input data and responses.
 	Channel interface{}
+
+	// The name of a queue. This is intended for display in log messages or
+	// other output to identify queues with pending items.
+	Name string
 
 	// Count is the number of items currently in the queue
 	Count int

--- a/config/config.go
+++ b/config/config.go
@@ -250,30 +250,9 @@ func Usage(flagSet *flag.FlagSet) func() {
 // command-line flags
 type Config struct {
 
-	// Retries is the number of attempts that this application will make
-	// to deliver messages before giving up.
-	Retries int
-
-	// RetriesDelay is the number of seconds to wait between retry attempts.
-	RetriesDelay int
-
-	// LocalTCPPort is the TCP port that this application should listen on for
-	// incoming requests
-	LocalTCPPort int
-
 	// LocalIPAddress is the IP Address that this application should listen on
 	// for incoming requests
 	LocalIPAddress string
-
-	// ColorizedJSON indicates whether JSON output should be colorized.
-	// Coloring the output could aid in in quick visual evaluation of incoming
-	// payloads
-	ColorizedJSON bool
-
-	// ColorizedJSONIndent controls how many spaces are used when indenting
-	// colorized JSON output. If ColorizedJSON is not enabled, this setting
-	// has no effect.
-	ColorizedJSONIndent int
 
 	// LogLevel is the chosen logging level
 	LogLevel string
@@ -295,6 +274,27 @@ type Config struct {
 	// advance by adding/configuring a Webhook Connector in a Microsoft Teams
 	// channel that you wish to submit messages to using this application.
 	WebhookURL string
+
+	// Retries is the number of attempts that this application will make
+	// to deliver messages before giving up.
+	Retries int
+
+	// RetriesDelay is the number of seconds to wait between retry attempts.
+	RetriesDelay int
+
+	// LocalTCPPort is the TCP port that this application should listen on for
+	// incoming requests
+	LocalTCPPort int
+
+	// ColorizedJSONIndent controls how many spaces are used when indenting
+	// colorized JSON output. If ColorizedJSON is not enabled, this setting
+	// has no effect.
+	ColorizedJSONIndent int
+
+	// ColorizedJSON indicates whether JSON output should be colorized.
+	// Coloring the output could aid in in quick visual evaluation of incoming
+	// payloads
+	ColorizedJSON bool
 }
 
 func (c *Config) String() string {

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -17,10 +17,10 @@ import (
 // API.
 type Route struct {
 	Name           string
-	AllowedMethods []string
 	Pattern        string
 	Description    string
 	HandlerFunc    http.HandlerFunc
+	AllowedMethods []string
 }
 
 // Routes is a collection of defined routes, intended for bulk registration


### PR DESCRIPTION
Change field order of `Config` struct to reduce allocation requirements and pass `fieldalignment` linting check.

fixes GH-127