### PR TITLE
Replace deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,10 +24,17 @@ linters:
     - depguard
     - prealloc
     - misspell
-    - maligned
     - dupl
     - unconvert
     - gofmt
     - golint
     - gocritic
-    - scopelint
+    - exportloopref
+
+  disable:
+    - maligned
+
+linters-settings:
+  govet:
+    enable:
+      - fieldalignment


### PR DESCRIPTION
- replace deprecated `maligned` linter with
  `govet: fieldalignment`
- replace deprecated `scopelint` linter with
  `exportloopref`

fixes GH-126