### PR TITLE
Lock Go version to the latest "oldstable" series

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@
 
 version: 2
 updates:
-
   # Enable version updates for Go modules
   - package-ecosystem: "gomod"
 
@@ -40,7 +39,6 @@ updates:
     commit-message:
       # Prefix all commit messages with "go.mod"
       prefix: "go.mod"
-
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -78,3 +76,10 @@ updates:
       - dependency-type: "all"
     commit-message:
       prefix: "canary"
+    ignore:
+      - dependency-name: "golang"
+        versions:
+          # Ignore updates from series associated with the latest "stable"
+          # Go release and no longer supported Go versions.
+          - ">= 1.17"
+          - "< 1.16"


### PR DESCRIPTION
Hold back from using the latest Go version until sufficient
testing has been performed.