### PR TITLE
Update project to Go 1.19

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,5 +81,5 @@ updates:
         versions:
           # Ignore updates from series associated with the latest "stable"
           # Go release and no longer supported Go versions.
-          - ">= 1.18"
-          - "< 1.17"
+          - ">= 1.20"
+          - "< 1.19"

--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -14,4 +14,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.17.13
+FROM golang:1.19.0

--- a/doc.go
+++ b/doc.go
@@ -1,80 +1,41 @@
 /*
-
 bounce is a small utility to assist with building HTTP endpoints
 
-
-PROJECT HOME
+# Project Home
 
 See our GitHub repo (https://github.com/atc0005/bounce) for the latest code,
 to file an issue or submit improvements for review and potential inclusion
 into the project.
 
-PURPOSE
+# Purpose
 
-bridge is primarily intended to be used as a HTTP endpoint for testing webhook
+bounce is primarily intended to be used as a HTTP endpoint for testing webhook
 payloads. Over time, it may grow other related features to aid in testing
 other tools that submit data via HTTP requests.
 
-FEATURES
+# Features
 
-• single binary, no outside dependencies
+  - single binary, no outside dependencies
+  - minimal configuration
+  - Optional submission of client request details to a user-specified
+    Microsoft Teams channel (by providing a webhook URL)
+  - index page automatically generated listing currently supported routes
+  - request body and associated metadata are echoed to stdout and back to
+    client
+  - echoed request details are provided as-is/unformatted when sent to the
+    /api/v1/echo/json endpoint
+  - JSON payloads to the /api/v1/echo/json endpoint are automatically
+    formatted
+  - Optional, colorization and custom ident control for formatted JSON output
+  - User configurable TCP port to listen on for incoming HTTP requests
+  - User configurable IP Address to listen on for incoming HTTP requests
+  - User configurable logging levels
+  - User configurable logging format
+  - User configurable logging output (stdout or stderr)
+  - User configurable message submission retry and retry delay limits
 
-• minimal configuration
+# Usage
 
-• Optional submission of client request details to a user-specified Microsoft Teams channel (by providing a webhook URL)
-
-• index page automatically generated listing currently supported routes
-
-• request body and associated metadata are echoed to stdout and back to client
-
-• echoed request details are provided as-is/unformatted when sent to the /api/v1/echo/json endpoint
-
-• JSON payloads to the /api/v1/echo/json endpoint are automatically formatted
-
-• Optional, colorization and custom ident control for formatted JSON output
-
-• User configurable TCP port to listen on for incoming HTTP requests
-
-• User configurable IP Address to listen on for incoming HTTP requests
-
-• User configurable logging levels
-
-• User configurable logging format
-
-• User configurable logging output (stdout or stderr)
-
-• User configurable message submission retry and retry delay limits
-
-USAGE
-
-Help output is below. See the README for examples.
-
-$ ./bounce.exe -h
-
-    bounce x.y.z
-    https://github.com/atc0005/bounce
-
-    Usage of "T:\github\bounce\bounce.exe":
-    -color
-            Whether JSON output should be colorized.
-    -indent-lvl int
-            Number of spaces to use when indenting colorized JSON output. Has no effect unless colorized JSON mode is enabled. (default 2)
-    -ipaddr string
-            Local IP Address that this application should listen on for incoming HTTP requests. (default "localhost")
-    -log-fmt string
-            Log messages are written in this format (default "text")
-    -log-lvl string
-            Log message priority filter. Log messages with a lower level are ignored. (default "info")
-    -log-out string
-            Log messages are written to this output target (default "stdout")
-    -port int
-            TCP port that this application should listen on for incoming HTTP requests. (default 8000)
-    -retries int
-            The number of attempts that this application will make to deliver messages before giving up. (default 2)
-    -retries-delay int
-            The number of seconds that this application will wait before making another delivery attempt. (default 2)
-    -webhook-url string
-            The Webhook URL provided by a preconfigured Connector. If specified, this application will attempt to send client request details to the Microsoft Teams channel associated with the webhook URL.
-
+See our main README for supported settings and examples.
 */
 package main

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@
 
 module github.com/atc0005/bounce
 
-go 1.17
+go 1.19
 
 // $ go list -m -versions github.com/apex/log
 // github.com/apex/log v1.0.0 v1.1.0 v1.1.1 v1.1.2


### PR DESCRIPTION
- update go.mod file from Go 1.17 to 1.19
- update doc.go file to use Go 1.19 package doc comments syntax
- update "Canary" Dockerfile to reflect current Go 1.19 version
- update Dependabot configuration for Dockerfile to ignore Go releases
  outside of the Go 1.19 release series