### PR TITLE
Linting fixes, add missing cmd doc file

### DIFF
--- a/cmd/bounce/doc.go
+++ b/cmd/bounce/doc.go
@@ -1,0 +1,20 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/bounce
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// bounce is primarily intended to be used as a HTTP endpoint for testing
+// webhook payloads. Over time, it may grow other related features to aid in
+// testing other tools that submit data via HTTP requests.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/bounce
+package main

--- a/cmd/bounce/handlers.go
+++ b/cmd/bounce/handlers.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	htmlTemplate "html/template"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	textTemplate "text/template"
@@ -183,7 +182,7 @@ func echoHandler(ctx context.Context, tmpl *textTemplate.Template, coloredJSON b
 
 				// Limit request body to 1 MB
 				r.Body = http.MaxBytesReader(w, r.Body, 1*MB)
-				requestBody, err := ioutil.ReadAll(r.Body)
+				requestBody, err := io.ReadAll(r.Body)
 				if err != nil {
 					errorMsg := fmt.Sprintf("Error reading request body: %s", err)
 					ourResponse.BodyError = errorMsg
@@ -261,7 +260,7 @@ func echoHandler(ctx context.Context, tmpl *textTemplate.Template, coloredJSON b
 
 				// read everything from the (size-limited) request body so
 				// that we can display it in a raw format
-				requestBody, err := ioutil.ReadAll(r.Body)
+				requestBody, err := io.ReadAll(r.Body)
 				if err != nil {
 					errorMsg := fmt.Sprintf("Error reading request body: %s", err)
 					ourResponse.BodyError = errorMsg
@@ -279,7 +278,7 @@ func echoHandler(ctx context.Context, tmpl *textTemplate.Template, coloredJSON b
 
 				// replace the Body with a new io.ReadCloser to allow later
 				// access to r.Body for JSON-decoding purposes
-				r.Body = ioutil.NopCloser(bytes.NewReader(requestBody))
+				r.Body = io.NopCloser(bytes.NewReader(requestBody))
 
 				ourResponse.Body = string(requestBody)
 

--- a/config/config.go
+++ b/config/config.go
@@ -172,7 +172,7 @@ const (
 	LogLevelDebug string = "debug"
 )
 
-// 	apex/log Handlers
+// apex/log Handlers
 // ---------------------------------------------------------
 // cli - human-friendly CLI output
 // discard - discards all logs


### PR DESCRIPTION
- add "package" doc file to resolve revive `package-comment`
  linting error surfaced by recent linter update
- swap io/ioutil package for io package