### PR TITLE
Add initial automated release build workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,21 @@
+# See LICENSE file in this repo for license details.
+
+name: Release Build
+
+on:
+  push:
+    tags:
+      # Match any semver tag, rely on the imported workflow to apply necessary
+      # logic to separate "stable" release builds from "prerelease" builds.
+      - "v[0-9]+.[0-9]+.*"
+
+jobs:
+  release_build:
+    name: Generate release build
+
+    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+    permissions:
+      contents: write
+      discussions: write
+
+    uses: atc0005/shared-project-resources/.github/workflows/release-build.yml@master


### PR DESCRIPTION
Provide workflow used to automate the creation of GitHub releases upon pushing a tag. The "upstream" workflow imported by this one applies conditional logic (based on tag name) to determine whether a stable or pre-release GitHub release is created.

By default, release assets are generated and provided by the release. Library projects explicitly forgo the explicit generation of release assets.

refs atc0005/todo#33
refs atc0005/todo#45
refs atc0005/todo#65
refs atc0005/shared-project-resources#141